### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,12 @@
 	<version>3.2.8</version>
 	<name>IK Analyzer 3</name>
 	<description>A dictionary and grammar-based Chinese segmenter.</description>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
change default encode

在执行`mvn install`的时候会出现编码问题,在pom.xml文件里添加了属性,使其安装的时候使用UTF-8编码,这样就没有问题了